### PR TITLE
Fixed example

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,7 +456,7 @@ user=> (fw/watch "/tmp" (fn [result] (prn "result" result)))
 nil
 user=> (spit "/tmp/foobar123.txt" "foo")
 nil
-user=> "result" {:path "/private/tmp/foobar123.txt", :type "create"}
+user=> "result" {:path "/private/tmp/foobar123.txt", :type :create}
 ```
 
 ## Run tests


### PR DESCRIPTION
The most recent [commit to pod-babashka-filewatcher](https://github.com/babashka/pod-babashka-filewatcher/commit/a93be5ab0ffbbda89b659b731d81280191928522) updates the `:type` field in the filewatcher returned data to be a keyword. This is shown with an excerpt in the [Async section](https://github.com/babashka/pods#async) of the readme. However, the example output did not get updated when this section was added.