### PR TITLE
Fix tests, remove accidental babashka code dependency, & add CI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   test:
     docker:
-      - image: circleci/clojure:openjdk-11-lein-2.9.8-bullseye
+      - image: clojure:openjdk-11-tools-deps-1.10.3.1087-slim-bullseye
     working_directory: ~/repo
     environment:
       LEIN_ROOT: "true"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,11 +12,15 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v1-dependencies-{{ checksum "project.clj" }}-{{ checksum "deps.edn" }}
+            - v1-dependencies-{{ checksum "deps.edn" }}
             # fallback to using latest cache if no exact match is found
             - v1-dependencies-
       - run: |
           script/test
+      - save_cache:
+          paths:
+            - ~/.m2
+          key: v1-dependencies-{{ checksum "deps.edn" }}
 workflows:
   version: 2
   ci:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,24 @@
+version: 2.1
+jobs:
+  test:
+    docker:
+      - image: circleci/clojure:openjdk-11-lein-2.9.8-bullseye
+    working_directory: ~/repo
+    environment:
+      LEIN_ROOT: "true"
+      BABASHKA_PLATFORM: linux
+    resource_class: large
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "project.clj" }}-{{ checksum "deps.edn" }}
+            # fallback to using latest cache if no exact match is found
+            - v1-dependencies-
+      - run: |
+          script/test
+workflows:
+  version: 2
+  ci:
+    jobs:
+      - test

--- a/script/test
+++ b/script/test
@@ -8,24 +8,25 @@ export BABASHKA_POD_TEST_SOCKET
 # format = edn
 BABASHKA_POD_TEST_FORMAT=edn
 echo "Testing edn"
-clojure -A:test -n babashka.pods.jvm-test
-clojure -A:sci:test -n babashka.pods.sci-test
+clojure -M:test -n babashka.pods.jvm-test
+clojure -M:sci:test -n babashka.pods.sci-test
+clojure -M:test -n babashka.pods.impl-test
 
 # format = json
 BABASHKA_POD_TEST_FORMAT=json
 echo "Testing json"
-clojure -A:test -n babashka.pods.jvm-test
-clojure -A:sci:test -n babashka.pods.sci-test
+clojure -M:test -n babashka.pods.jvm-test
+clojure -M:sci:test -n babashka.pods.sci-test
 
 # format = json
 BABASHKA_POD_TEST_FORMAT="transit+json"
 echo "Testing transit"
-clojure -A:test -n babashka.pods.jvm-test
-clojure -A:sci:test -n babashka.pods.sci-test
+clojure -M:test -n babashka.pods.jvm-test
+clojure -M:sci:test -n babashka.pods.sci-test
 
 # socket = true
 unset BABASHKA_POD_TEST_FORMAT
 BABASHKA_POD_TEST_SOCKET=true
 echo "Testing socket"
-clojure -A:test -n babashka.pods.jvm-test
-clojure -A:sci:test -n babashka.pods.sci-test
+clojure -M:test -n babashka.pods.jvm-test
+clojure -M:sci:test -n babashka.pods.sci-test

--- a/src/babashka/pods/impl.clj
+++ b/src/babashka/pods/impl.clj
@@ -315,6 +315,11 @@
     (println (str/join " " (map pr-str strs)))))
 
 (defn resolve-pod [pod-spec {:keys [:version :path :force] :as opts}]
+  (when (qualified-symbol? pod-spec)
+    (when (and (not version) (not path))
+      (throw (IllegalArgumentException. "Version or path must be provided")))
+    (when (and version path)
+      (throw (IllegalArgumentException. "You must provide either version or path, not both"))))
   (let [resolved (when (and (qualified-symbol? pod-spec) version)
                    (resolver/resolve pod-spec version force))
         opts (if resolved

--- a/src/babashka/pods/jvm.clj
+++ b/src/babashka/pods/jvm.clj
@@ -6,7 +6,7 @@
 (defn- unroot-resource [^String path]
   (symbol (.. path
               (substring 1)
-              (replace \/ \. )
+              (replace \/ \.)
               (replace \_ \-))))
 
 (defn- process-namespace [{:keys [:name :vars]}]

--- a/test-pod/pod/test_pod.clj
+++ b/test-pod/pod/test_pod.clj
@@ -270,6 +270,6 @@
 
 (defn -main [& args]
   #_(binding [*out* *err*]
-    (prn :args args))
+      (prn :args args))
   (when (= "true" (System/getenv "BABASHKA_POD"))
     (run-pod (set args))))

--- a/test-resources/pod_registry.clj
+++ b/test-resources/pod_registry.clj
@@ -1,6 +1,6 @@
 (require '[babashka.pods :as pods])
 
-(pods/load-pod 'org.babashka/buddy "0.0.1")
+(pods/load-pod 'org.babashka/buddy "0.1.0")
 
 (require '[pod.babashka.buddy.codecs :as codecs]
          '[pod.babashka.buddy.hash :as hash])

--- a/test-resources/pod_registry.clj
+++ b/test-resources/pod_registry.clj
@@ -8,4 +8,4 @@
 (println (-> (hash/sha256 "foobar")
              (codecs/bytes->hex)))
 
-(pods/load-pod 'org.babashka/etaoin) ;; should cause error when version is missing
+(pods/load-pod 'org.babashka/etaoin) ;; should cause error when version & path are missing

--- a/test/babashka/pods/impl_test.clj
+++ b/test/babashka/pods/impl_test.clj
@@ -1,0 +1,11 @@
+(ns babashka.pods.impl-test
+  (:require [clojure.test :refer :all]
+            [babashka.pods.impl :refer :all]))
+
+(deftest load-pod-test
+  (testing "resolve fn gets called when pod has EDN data readers"
+    (let [resolved? (atom false)
+          test-resolve (fn [_sym]
+                         (reset! resolved? true))]
+      (load-pod ["clojure" "-M:test-pod"] {:resolve test-resolve})
+      (is @resolved?))))

--- a/test/babashka/pods/jvm_test.clj
+++ b/test/babashka/pods/jvm_test.clj
@@ -25,4 +25,4 @@
                    (catch Exception e
                      e)))]
     (is (str/includes? (str out) "c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2"))
-    (is (str/includes? (pr-str ex) "Version must be provided" ))))
+    (is (str/includes? (pr-str ex) "Version or path must be provided"))))

--- a/test/babashka/pods/sci_test.clj
+++ b/test/babashka/pods/sci_test.clj
@@ -36,4 +36,4 @@
                   (catch Exception e
                     e)))]
     (is (str/includes? (str out) "c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2"))
-    (is (str/includes? (pr-str ex) "Version must be provided" ))))
+    (is (str/includes? (pr-str ex) "Version must be provided"))))

--- a/test/babashka/pods/sci_test.clj
+++ b/test/babashka/pods/sci_test.clj
@@ -36,4 +36,4 @@
                   (catch Exception e
                     e)))]
     (is (str/includes? (str out) "c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2"))
-    (is (str/includes? (pr-str ex) "Version must be provided"))))
+    (is (str/includes? (pr-str ex) "Version or path must be provided"))))


### PR DESCRIPTION
When I went to add a test for the `resolve` bug fixed in #44 I noticed that other tests weren't passing and that it was because of some expectations broken by my changes in that same PR. That made me wonder why that hadn't been caught in CI and I noticed that no CI config was present in this repo. When I went to set that up, I realized I had inadvertently created a code dependency from pods -> babashka, which didn't seem good (so, for example, you couldn't run pods's tests unless it was embedded as a submodule in babashka).

So this PR fixes all of the above and adds a test for the original `resolve` bug too. Let me know if you want me to remove anything or split it out into a separate PR.