### PR TITLE
set TCP_NODELAY on transport socket

### DIFF
--- a/src/babashka/pods/impl.clj
+++ b/src/babashka/pods/impl.clj
@@ -292,7 +292,8 @@
    the socket is connected."
   ^Socket
   [^String hostname ^Integer port]
-  (Socket. hostname port))
+  (doto (Socket. hostname port)
+    (.setTcpNoDelay true)))
 
 (defn close-socket
   "Close the socket, and also closes its input and output streams."


### PR DESCRIPTION
When using `:transport :socket` on a pod, setting TCP_NODELAY on both sides (should also be set in the pod) of the connection speeds up calls 100x.

Testing with 1449 invoke and responses:

before: "Elapsed time: 127872.209778 msecs" = 88 msecs per round trip.

after: "Elapsed time: 1219.170753 msecs" = 0.84 msecs per round trip
