### PR TITLE
Switch "out" and "err" messages to print and flush instead of println

### DIFF
--- a/src/babashka/pods/impl.clj
+++ b/src/babashka/pods/impl.clj
@@ -219,9 +219,12 @@
                 ;; listening to output synchronous.
                 (when out
                   (binding [*out* out-stream]
-                    (println out)))
-                (when err (binding [*out* err-stream]
-                            (println err)))
+                    (print out)
+                    (.flush ^java.io.Writer out-stream)))
+                (when err
+                  (binding [*out* err-stream]
+                    (print err)
+                    (.flush ^java.io.Writer err-stream)))
                 (when (or value* error? namespace)
                   (cond promise?
                         (deliver chan (cond error? exception

--- a/test-pod/pod/test_pod.clj
+++ b/test-pod/pod/test_pod.clj
@@ -207,14 +207,14 @@
                               "id" id})
                             pod.test-pod/print
                             (do (write out
-                                 {"out" (pr-str args)
+                                 {"out" (with-out-str (prn args))
                                   "id" id})
                                 (write out
                                  {"status" ["done"]
                                   "id" id}))
                             pod.test-pod/print-err
                             (do (write out
-                                 {"err" (pr-str args)
+                                 {"err" (with-out-str (prn args))
                                   "id" id})
                                 (write out
                                  {"status" ["done"]


### PR DESCRIPTION
This fixes #56.